### PR TITLE
Rails 4.2 support 

### DIFF
--- a/lib/endpoint_base/concerns/rails_responder.rb
+++ b/lib/endpoint_base/concerns/rails_responder.rb
@@ -17,7 +17,7 @@ module EndpointBase::Concerns
       end
 
       def process_result(code)
-        render "#{EndpointBase.path_to_views}/application/response.json", status: code
+        render file: "#{EndpointBase.path_to_views}/application/response.json", status: code
       end
     end
   end


### PR DESCRIPTION
I'm trying to move to Rails 4.2 and it looks like this small change is necessary to endpoint_base.

For reference:
http://guides.rubyonrails.org/4_2_release_notes.html#render-with-a-string-argument

This shouldn't break anything in earlier versions. It's just a more explicit version of what was already going down... i think.